### PR TITLE
Fix for building on Solaris

### DIFF
--- a/iconv.cc
+++ b/iconv.cc
@@ -80,7 +80,7 @@ int convert(iconv_t iv, char* input, size_t inlen, char** output, size_t* outlen
   // convert input
   do {
     if (grow(output, outlen, &outbuf, &outbufsz)) {
-      rv = iconv(iv, &inbuf, &inbufsz, &outbuf, &outbufsz);
+      rv = iconv(iv, (const char**) &inbuf, &inbufsz, &outbuf, &outbufsz);
     }
     else {
       goto error;


### PR DESCRIPTION
The original code could not build on Solaris.
I tried to build on JoyentCloud SmartMachine.

Fix for type casting error from char*\* to const char*\* on Solaris(s.t. no.de).
