### PR TITLE
Improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Text recoding in JavaScript for fun and profit!
 
+Note that node-iconv does not support Windows.
+
 ## Installing with [npm](http://npmjs.org/)
 
 	npm install iconv


### PR DESCRIPTION
According to the issue described on https://github.com/bnoordhuis/node-iconv/issues/27 , it is currently not possible to use node-iconv on Windows.

It is much more convenient to have this information explicitly stated in readme instead of getting some unclear error message when trying to `npm install iconv`.
