### PR TITLE
add .npmignore for deps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+deps/libiconv/tests


### PR DESCRIPTION
Currently deps  dir have arround 20MB, what makes my package (using npm pack) quite large. 
Can we add .npmignore to ignore all the stuff in deps dir which isn't necessary (for example tests - 7MB) ?
