### PR TITLE
Fix node version check

### DIFF
--- a/src/iconv.cc
+++ b/src/iconv.cc
@@ -24,7 +24,7 @@
 
 #include "node_version.h"
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION <= 8
+#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION >= 8
 # define GetAlignedPointerFromInternalField GetPointerFromInternalField
 # define SetAlignedPointerInInternalField SetPointerInInternalField
 #endif


### PR DESCRIPTION
There was a minor typo in your version checking. The 2 methods are removed FROM version 0.8.x. Currently the build breaks with node version 0.9.x. This pull-request fixes it.
