### PR TITLE
'this.write' also needs "if (typeof(input) === 'string') input = new Buffer(input);"

### DIFF
--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -106,6 +106,7 @@ function Iconv(fromEncoding, toEncoding)
 
   this.write = function(input) {
     try {
+      if (typeof(input) === 'string') input = new Buffer(input);
       var buf = convert(input);
     }
     catch (e) {


### PR DESCRIPTION
...er(input);

I tryed 'res.pipe(iconv).pipe(res)'.
Its argument is string type.
