### PR TITLE
[fix] pass a base64 string to iconv.convert()

### DIFF
--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -86,7 +86,8 @@ function fixEncoding(encoding)
 
 function convert(input, context) {
   if (typeof(input) === 'string') {
-    input = new Buffer(input);
+    var encoding = typeof arguments[1] === 'string' ? arguments[1] : 'utf8';
+    input = new Buffer(input, encoding);
   }
   if (!(input instanceof Buffer) && input !== FLUSH) {
     throw new Error('Bad argument.');  // Not a buffer or a string.


### PR DESCRIPTION
Like the below:

``` javascript
var Iconv = require('iconv').Iconv;
var iconv = new Iconv('GB2312', 'UTF-8');
var buf = new Buffer('uMm77rrDsMk=', 'base64');

var result = iconv.convert(buf);
console.log(result.toString('utf8'))
```

It don't return the correct result. Because of the error call for `new Buffer(input)`, the correct way is to do `new Buffer(input, encoding)`, the following code is mine:

``` javascript

var Iconv = require('iconv').Iconv;
var iconv = new Iconv('GB2312', 'UTF-8');
var result = iconv.convert('uMm77rrDsMk=', 'base64');
console.log(result.toString('utf8'))
```
