### PR TITLE
Get back DOS, AIX encodings.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
       'direct_dependent_settings': {
         'include_dirs':  ['support'],
       },
-      'defines': ['ICONV_CONST=const', 'USE_EXTRA=1'],
+      'defines': ['ICONV_CONST=const', 'ENABLE_EXTRA=1'],
       'include_dirs': [
         'deps/libiconv/srclib',
         'support',


### PR DESCRIPTION
After commit e7053b22bb76c40d529b48def216200b1438db12, encodings cp{437, 737, 775, 852, 855-858, 860, 861, 863-865, 869, 922, 1046, 1124, 1125, 1129, 1161-1163} are no longer available (I'm testing against them in iconv-lite). 

Seems that `USE_EXTRA` does not imply `USE_AIX`, `USE_DOS` and `USE_OSF1`, so these encodings were not compiled in. But `ENABLE_EXTRA` does! (see https://github.com/bnoordhuis/node-iconv/blob/master/deps/libiconv/lib/iconv.c#L31)

So, to re-enable these encodings, I propose this PR :)
 
