### PR TITLE
Handle partial multibyte characters in the last chunk

### DIFF
--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -96,6 +96,9 @@ function convert(input, context) {
   if (!(input instanceof Buffer) && input !== FLUSH) {
     throw new Error('Bad argument.');  // Not a buffer or a string.
   }
+  if (context !== null && context.trailer !== null && input === FLUSH) {
+    throw errnoException('EINVAL', 'Incomplete character sequence.');
+  }
   if (context !== null && context.trailer !== null) {
     // Prepend input buffer with trailer from last chunk.
     var newbuf = new Buffer(context.trailer.length + input.length);

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -169,3 +169,30 @@ assert(new Iconv('ascii', 'ascii') instanceof stream.Stream);
   stream.end('b2s=', 'base64');
   assert(ok);
 })();
+
+(function() {
+  var ok = false;
+  var stream = Iconv('gb18030', 'utf-8');
+  stream.once('error', function (e) {
+    assert.equal(e.message, 'Incomplete character sequence.');
+    assert.equal(e.code, 'EINVAL');
+    ok = true;
+  });
+  var octets = [
+    0x00, 0xf1, 0x52, 0x00, 0x00, 0x78, 0x51, 0xd9, 0xf7, 0x78, 0x51, 0xd9
+  ];
+  stream.end(new Buffer(octets));
+  assert(ok);
+})();
+
+(function() {
+  var ok = false;
+  var stream = Iconv('utf-8', 'utf-16');
+  stream.once('error', function (e) {
+    assert.equal(e.message, 'Incomplete character sequence.');
+    assert.equal(e.code, 'EINVAL');
+    ok = true;
+  });
+  stream.end(new Buffer([0xc3]));
+  assert(ok);
+})();


### PR DESCRIPTION
I found some customer data that reproduced the error that previously were reported in #75. It turned out to be caused by two things - one internal error in our own code, and the problem that this pull request aims to fix.

Because the last character in the two test cases is a partial multi-byte character, the convert method ends up being called with a FLUSH sentinel and a context which has the trailer of the partial multi-byte character.

The first test case (from gb18030 charset) is from a real world example - the latter test case (from utf-8) is an synthetic one to validate the suspicion. 

We do not need to rely on iconv to tell us that we have an incomplete character sequence, when we get that situation, so we can bail out early.