### PR TITLE
If charsets are not supported, include what they are in the error

### DIFF
--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -47,7 +47,7 @@ function Iconv(fromEncoding, toEncoding)
 
   var conv = bindings.make(fixEncoding(fromEncoding),
                            fixEncoding(toEncoding));
-  if (conv === null) throw new Error('Conversion not supported.');
+  if (conv === null) throw new Error('Conversion from '+fromEncoding+' to '+toEncoding+' is not supported.');
 
   var convert_ = convert.bind({ conv_: conv });
   var context_ = { trailer: null };


### PR DESCRIPTION
saves a lot on debugging