### PR TITLE
Include charset names in error message

### DIFF
--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -47,7 +47,10 @@ function Iconv(fromEncoding, toEncoding)
 
   var conv = bindings.make(fixEncoding(fromEncoding),
                            fixEncoding(toEncoding));
-  if (conv === null) throw new Error('Conversion not supported.');
+  if (conv === null) {
+    throw new Error('Conversion from '+fromEncoding+' to '+
+                    toEncoding+' is not supported.');
+  }
 
   var convert_ = convert.bind({ conv_: conv });
   var context_ = { trailer: null };

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -44,6 +44,21 @@ assert.deepEqual(iconv.convert(new Buffer('xxx')), new Buffer('xxx'));
 var buffer = new Buffer(1); buffer[0] = 235; // ë
 assert.deepEqual(iconv.convert('ë'), buffer);
 
+// test conversion error messages
+var unknown_conv = "whatchimajig";
+try {
+  new Iconv("utf-8", unknown_conv);
+} catch (e) {
+  assert.equal(e.message, "Conversion from utf-8 to "+
+               unknown_conv+" is not supported.");
+}
+try {
+  new Iconv(unknown_conv, "utf-8");
+} catch (e) {
+  assert.equal(e.message, "Conversion from "+
+               unknown_conv+" to utf-8 is not supported.");
+}
+
 // partial character sequence should throw EINVAL
 buffer = new Buffer(1); buffer[0] = 195;
 try {


### PR DESCRIPTION
Including charset names helps with debugging, avoiding to re-throw,
or adding debugging statements arround.