### PR TITLE
#145 Added support for Locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Text recoding in JavaScript for fun and profit!
 
+Fork from [bnoordhuis/node-iconv](https://github.com/bnoordhuis/node-iconv)
+
+This fork admits use locales for better transliterations. It changes the API, the bindings implementations and it uses the SO library instead of the supplied library in the repo.
+
+It adds a new (third) parameter in the contructor. 
+It needs to be a valid locale for LC_ALL in the `std::setLocale(LC_ALL, locale)` C++ function.
+
+``` javascript
+    var iconv = new Iconv('UTF-8', 'ASCII', 'de_DE.UTF-8'); //'en_US.UTF-8' is the locations. Can be undefined or a valid LANG value.
+    iconv.convert('ü  ä  ö  ß  Ü  Ä  Ö ç ñ').toString(); //ue  ae  oe  ss  UE  AE  OE c n
+```
+
 ## Supported encodings
 
     European languages
@@ -89,7 +101,7 @@ Encode from one character encoding to another:
     var Iconv  = require('iconv').Iconv;
     var assert = require('assert');
 
-    var iconv = new Iconv('UTF-8', 'ISO-8859-1');
+    var iconv = new Iconv('UTF-8', 'ISO-8859-1', 'en_US.UTF-8');
     var buffer = iconv.convert('Hello, world!');
     var buffer2 = iconv.convert(new Buffer('Hello, world!'));
     assert.equals(buffer.inspect(), buffer2.inspect());
@@ -100,7 +112,7 @@ A simple ISO-8859-1 to UTF-8 conversion TCP service:
     var net = require('net');
     var Iconv = require('iconv').Iconv;
     var server = net.createServer(function(conn) {
-      var iconv = new Iconv('latin1', 'utf-8');
+      var iconv = new Iconv('latin1', 'utf-8', 'en_US.UTF-8');
       conn.pipe(iconv).pipe(conn);
     });
     server.listen(8000);
@@ -148,16 +160,16 @@ encountered but this can be customized. Quoting the `iconv_open(3)` man page:
 
 Example usage:
 
-    var iconv = new Iconv('UTF-8', 'ASCII');
+    var iconv = new Iconv('UTF-8', 'ASCII', 'en_US.UTF-8');
     iconv.convert('ça va'); // throws EILSEQ
 
-    var iconv = new Iconv('UTF-8', 'ASCII//IGNORE');
+    var iconv = new Iconv('UTF-8', 'ASCII//IGNORE', 'en_US.UTF-8');
     iconv.convert('ça va'); // returns "a va"
 
-    var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT');
+    var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT', 'en_US.UTF-8');
     iconv.convert('ça va'); // "ca va"
 
-    var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE');
+    var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'en_US.UTF-8');
     iconv.convert('ça va が'); // "ca va "
 
 ### EINVAL

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,6 @@
   'targets': [
     {
       'target_name': 'iconv',
-      'dependencies': ['libiconv'],
       'include_dirs': ['<!(node -e "require(\'nan\')")'],
       'sources': ['src/binding.cc'],
       'cflags': [
@@ -19,45 +18,5 @@
         'WARNING_CFLAGS': ['-Wall', '-Wextra', '-Wno-unused-parameter'],
       },
     },
-
-    {
-      'target_name': 'libiconv',
-      'type': 'static_library',
-      'direct_dependent_settings': {
-        'include_dirs':  ['support'],
-      },
-      'defines': ['ICONV_CONST=const', 'ENABLE_EXTRA=1'],
-      'include_dirs': [
-        'deps/libiconv/srclib',
-        'support',
-      ],
-      'sources': ['deps/libiconv/lib/iconv.c'],
-      'conditions': [
-        ['OS == "win"', {
-          'defines': ['WIN32_NATIVE=1'],
-        }, {
-          'defines': ['HAVE_WORKING_O_NOFOLLOW=1'],
-          'cflags!': ['-W', '-Wall', '-Wextra'],
-        }],
-      ],
-      'msvs_settings': {
-        'VCCLCompilerTool': {
-          'DisableSpecificWarnings': [
-            '4018',  # Signed/unsigned comparison.
-            '4090',  # Const/non-const mismatch.
-            '4244',  # Narrowing cast.
-            '4267',  # Narrowing cast.
-          ],
-        },
-      },
-      'xcode_settings': {
-        'WARNING_CFLAGS!': ['-W', '-Wall', '-Wextra'],
-        'WARNING_CFLAGS': [
-          '-Wno-parentheses-equality',
-          '-Wno-static-in-inline',
-          '-Wno-tautological-compare',
-        ],
-      },
-    }
   ]
 }

--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -36,7 +36,7 @@ var EINVAL = bindings.EINVAL | 0;
 // Marker object.
 var FLUSH = {};
 
-function Iconv(fromEncoding, toEncoding)
+function Iconv(fromEncoding, toEncoding, locale)
 {
   if (!(this instanceof Iconv)) {
     return new Iconv(fromEncoding, toEncoding);
@@ -46,7 +46,8 @@ function Iconv(fromEncoding, toEncoding)
   this.writable = true;
 
   var conv = bindings.make(fixEncoding(fromEncoding),
-                           fixEncoding(toEncoding));
+                           fixEncoding(toEncoding),
+                           locale);
   if (conv === null) {
     throw new Error('Conversion from ' +
                     fromEncoding + ' to ' +

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -79,6 +79,8 @@ struct Iconv
   {
     String::Utf8Value from_encoding(info[0]);
     String::Utf8Value to_encoding(info[1]);
+    String::Utf8Value locale(info[2]);
+    std::setlocale(LC_ALL, *locale);
     iconv_t conv = iconv_open(*to_encoding, *from_encoding);
     if (conv == reinterpret_cast<iconv_t>(-1)) {
       return info.GetReturnValue().SetNull();
@@ -97,8 +99,7 @@ struct Iconv
     Iconv* iv = static_cast<Iconv*>(
         Nan::GetInternalFieldPointer(info[0].As<Object>(), 0));
     const bool is_flush = info[8]->BooleanValue();
-    const char* input_buf =
-        is_flush ? NULL : node::Buffer::Data(info[1].As<Object>());
+    const char* input_buf = is_flush ? NULL : node::Buffer::Data(info[1].As<Object>());
     size_t input_start = info[2]->Uint32Value();
     size_t input_size = info[3]->Uint32Value();
     char* output_buf = node::Buffer::Data(info[4].As<Object>());
@@ -109,11 +110,7 @@ struct Iconv
     output_buf += output_start;
     size_t input_consumed = input_size;
     size_t output_consumed = output_size;
-    size_t nconv = iconv(iv->conv_,
-                         &input_buf,
-                         &input_size,
-                         &output_buf,
-                         &output_size);
+    size_t nconv = iconv(iv->conv_, (char**)&input_buf, &input_size, (char**)&output_buf, &output_size);
     int errorno = 0;
     if (nconv == static_cast<size_t>(-1)) {
       errorno = errno;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,12 @@
+var Iconv = require('./lib/iconv.js').Iconv;
+
+var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'de_DE.UTF-8');
+
+
+var time = Date.now();
+
+var data = iconv.convert('ü  ä  ö  ß  Ü  Ä  Ö {"·45 g kjshdflkj hl sññplñlñl+çñç').toString();
+
+console.log(Date.now() - time);
+
+console.log(data);

--- a/test.js
+++ b/test.js
@@ -1,12 +1,37 @@
 var Iconv = require('./lib/iconv.js').Iconv;
 
-var iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'de_DE.UTF-8');
+var iconvDE = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'de_DE.UTF-8');
+var iconvEN = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'en_US.UTF-8');
 
+var ITERATIONS = 10000;
+var TEST_STRING = 'ü  ä  ö  ß  Ü  Ä  Ö {"·45 g kjshdflkj hl sññplñlñl+çñç';
+var GERMAN_TRANSLITERATION = 'ue  ae  oe  ss  UE  AE  OE {"?45 g kjshdflkj hl snnplnlnl+cnc';
+var ENGLISH_TRANSLITERATION = 'u  a  o  ss  U  A  O {"?45 g kjshdflkj hl snnplnlnl+cnc';
 
 var time = Date.now();
 
-var data = iconv.convert('ü  ä  ö  ß  Ü  Ä  Ö {"·45 g kjshdflkj hl sññplñlñl+çñç').toString();
+for(var i = ITERATIONS; i >= 0; i--){
+	iconvDE.convert(TEST_STRING).toString();
+}
 
-console.log(Date.now() - time);
+console.log('Time for ' + ITERATIONS + ' iterations with ' + TEST_STRING.length + ' characters string: ' + (Date.now() - time) + 'ms');
 
-console.log(data);
+if(testDE() && testC() && testC() && testDE() && testDE() && testDE() && testC() && testDE())
+	console.log('All test OK');
+else
+	console.log('Test FAIL');
+
+
+
+function testDE (iconv) {
+	if(iconvDE.convert(TEST_STRING).toString() !== GERMAN_TRANSLITERATION)
+		return false;	
+	return true;
+}
+
+function testC (iconv) {
+	if(iconvEN.convert(TEST_STRING).toString() !== ENGLISH_TRANSLITERATION)
+		return false;
+	
+	return true;
+}

--- a/test/test-big-buffer.js
+++ b/test/test-big-buffer.js
@@ -19,7 +19,7 @@
 var Iconv = require('../lib/iconv').Iconv;
 var assert = require('assert');
 
-var iconv = new Iconv('UTF-8', 'UTF-16LE');
+var iconv = new Iconv('UTF-8', 'UTF-16LE', 'de_DE.UTF-8');
 
 var utf8 = new Buffer(20000000);
 for (var i = 0; i < utf8.length; i++) {

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -23,7 +23,7 @@ var net = require('net');
 var fs = require('fs');
 var PORT = 12345;
 
-assert(new Iconv('ascii', 'ascii') instanceof stream.Stream);
+assert(new Iconv('ascii', 'ascii', 'de_DE.UTF-8') instanceof stream.Stream);
 
 (function() {
   var infile = __dirname + '/fixtures/lorem-ipsum.txt';


### PR DESCRIPTION
#145

It's uses the iconv SO lib now.  

I hope this can be useful, but It's not suitable for merge. It change the iconv library and makes the library slow. 

ussage:

``` javascript
var iconvDE = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', 'de_DE.UTF-8');
iconv.convert('ü  ä  ö  ß  Ü  Ä  Ö ç ñ').toString(); //ue  ae  oe  ss  UE  AE  OE c n
```