### PR TITLE
Updated nan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.2.1"
+    "nan": "~2.3.5"
   },
   "devDependencies": {
     "tap": "~0.4.8"


### PR DESCRIPTION
Fixes issues when running on node v6.

For example, compiling with older nan can result in the following warning:

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.
```