### PR TITLE
Fix NAN dependency to use newer version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.2.1"
+    "nan": "2.3.5"
   },
   "devDependencies": {
     "tap": "~0.4.8"


### PR DESCRIPTION
This fixes issues with newer nodejs versions, such as v6.2.0. Tested on Linux and verified to work.