### PR TITLE
iconv: Ensure all created buffers are filled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Encode from one character encoding to another:
 
     var iconv = new Iconv('UTF-8', 'ISO-8859-1');
     var buffer = iconv.convert('Hello, world!');
-    var buffer2 = iconv.convert(new Buffer('Hello, world!'));
+    var buffer2 = iconv.convert(Buffer.from('Hello, world!'));
     assert.equals(buffer.inspect(), buffer2.inspect());
     // do something useful with the buffers
 

--- a/lib/iconv.js
+++ b/lib/iconv.js
@@ -59,14 +59,14 @@ function Iconv(fromEncoding, toEncoding)
 
   this.convert = function(input, encoding) {
     if (typeof(input) === 'string') {
-      input = new Buffer(input, encoding || 'utf8');
+      input = Buffer.from(input, encoding || 'utf8');
     }
     return convert_(input, null);
   };
 
   this.write = function(input, encoding) {
     if (typeof(input) === 'string') {
-      input = new Buffer(input, encoding || 'utf8');
+      input = Buffer.from(input, encoding || 'utf8');
     }
     try {
       var buf = convert_(input, context_);
@@ -107,13 +107,13 @@ function convert(input, context) {
   }
   if (context !== null && context.trailer !== null) {
     // Prepend input buffer with trailer from last chunk.
-    var newbuf = new Buffer(context.trailer.length + input.length);
+    var newbuf = Buffer.alloc(context.trailer.length + input.length);
     context.trailer.copy(newbuf, 0, 0, context.trailer.length);
     input.copy(newbuf, context.trailer.length, 0, input.length);
     context.trailer = null;
     input = newbuf;
   }
-  var output = new Buffer(input.length * 2);  // To a first approximation.
+  var output = Buffer.alloc(input.length * 2);  // To a first approximation.
   var input_start = 0;
   var output_start = 0;
   var input_size = input.length;
@@ -138,7 +138,7 @@ function convert(input, context) {
     if (errno) {
       if (errno === E2BIG) {
         output_size += output.length;
-        var newbuf = new Buffer(output.length * 2);
+        var newbuf = Buffer.alloc(output.length * 2);
         output.copy(newbuf, 0, 0, output_start);
         output = newbuf;
         continue;

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -38,13 +38,13 @@ assert.throws(function() { iconv.convert() });
 assert.throws(function() { iconv.convert(1) });
 assert.throws(function() { iconv.convert({}) });
 
-assert(iconv.convert(new Buffer('xxx')) instanceof Buffer);
+assert(iconv.convert(Buffer.from('xxx')) instanceof Buffer);
 assert(iconv.convert('xxx') instanceof Buffer);
 
-assert.deepEqual(iconv.convert('xxx'), new Buffer('xxx'));
-assert.deepEqual(iconv.convert(new Buffer('xxx')), new Buffer('xxx'));
+assert.deepEqual(iconv.convert('xxx'), Buffer.from('xxx'));
+assert.deepEqual(iconv.convert(Buffer.from('xxx')), Buffer.from('xxx'));
 
-var buffer = new Buffer(1); buffer[0] = 235; // ë
+var buffer = Buffer.alloc(1); buffer[0] = 235; // ë
 assert.deepEqual(iconv.convert('ë'), buffer);
 
 // test conversion error messages
@@ -68,7 +68,7 @@ try {
 }
 
 // partial character sequence should throw EINVAL
-buffer = new Buffer(1); buffer[0] = 195;
+buffer = Buffer.alloc(1); buffer[0] = 195;
 try {
   iconv.convert(buffer);
 } catch (e) {
@@ -76,20 +76,20 @@ try {
 }
 
 // belongs to partial character sequence test - new input should be recoded without issues
-buffer = new Buffer(1); buffer[0] = 235; // ë
+buffer = Buffer.alloc(1); buffer[0] = 235; // ë
 assert.deepEqual(iconv.convert('ë'), buffer);
 
 // stateful encodings should do the Right Thing
 iconv = new Iconv('iso-2022-jp', 'utf-8');
-buffer = new Buffer(5);
+buffer = Buffer.alloc(5);
 buffer[0] = 0x1b;  // start escape sequence
 buffer[1] = 0x24;
 buffer[2] = 0x40;
 buffer[3] = 0x24;  // start character sequence
 buffer[4] = 0x2c;
-assert.deepEqual(iconv.convert(buffer), new Buffer('が'));
+assert.deepEqual(iconv.convert(buffer), Buffer.from('が'));
 
-buffer = new Buffer(4);
+buffer = Buffer.alloc(4);
 buffer[0] = 0x1b;  // start escape sequence
 buffer[1] = 0x24;
 buffer[2] = 0x40;

--- a/test/test-big-buffer.js
+++ b/test/test-big-buffer.js
@@ -21,7 +21,7 @@ var assert = require('assert');
 
 var iconv = new Iconv('UTF-8', 'UTF-16LE');
 
-var utf8 = new Buffer(20000000);
+var utf8 = Buffer.alloc(20000000);
 for (var i = 0; i < utf8.length; i++) {
   utf8[i] = 97 + i % 26; // cycle from 'a' to 'z'.
 }

--- a/test/test-stream.js
+++ b/test/test-stream.js
@@ -181,7 +181,7 @@ assert(new Iconv('ascii', 'ascii') instanceof stream.Stream);
   var octets = [
     0x00, 0xf1, 0x52, 0x00, 0x00, 0x78, 0x51, 0xd9, 0xf7, 0x78, 0x51, 0xd9
   ];
-  stream.end(new Buffer(octets));
+  stream.end(Buffer.from(octets));
   assert(ok);
 })();
 
@@ -193,6 +193,6 @@ assert(new Iconv('ascii', 'ascii') instanceof stream.Stream);
     assert.equal(e.code, 'EINVAL');
     ok = true;
   });
-  stream.end(new Buffer([0xc3]));
+  stream.end(Buffer.from([0xc3]));
   assert(ok);
 })();


### PR DESCRIPTION
Use of the buffer constructor was deprecated in Node.js 10. The
recommended way to create a new buffer is to use Buffer.alloc(num) when
creating an empty buffer or Buffer.from(stringish) when creating a
buffer from some given input.

Tests pass.

Closes #181.