### PR TITLE
bumped nan package version to 2.10.0 for Node 10 compatability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "iconv",
+  "version": "2.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "^2.3.5"
+    "nan": "^2.10.0"
   },
   "scripts": {
     "test": "node test/run-tests.js"


### PR DESCRIPTION
node-gyp throws errors when built against Node.js 10.7.0

Bumping `nan` package to recent version seems to fix the problem. Tested on Node 8.11 LTS and 10.7