### PR TITLE
src: use `Nan::SetMethod()` for exports

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -30,14 +30,11 @@ namespace
 {
 
 using v8::Array;
-using v8::Boolean;
 using v8::Integer;
 using v8::Local;
-using v8::Null;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
-using v8::Value;
 
 
 struct Iconv

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -31,7 +31,6 @@ namespace
 
 using v8::Array;
 using v8::Boolean;
-using v8::FunctionTemplate;
 using v8::Integer;
 using v8::Local;
 using v8::Null;
@@ -66,14 +65,8 @@ struct Iconv
     Local<ObjectTemplate> t = Nan::New<ObjectTemplate>();
     t->SetInternalFieldCount(1);
     object_template.Reset(t);
-    Nan::Set(obj,
-             Nan::New<String>("make").ToLocalChecked(),
-             Nan::GetFunction(
-               Nan::New<FunctionTemplate>(Make)).ToLocalChecked());
-    Nan::Set(obj,
-             Nan::New<String>("convert").ToLocalChecked(),
-             Nan::GetFunction(
-               Nan::New<FunctionTemplate>(Convert)).ToLocalChecked());
+    Nan::SetMethod(obj, "make", Make);
+    Nan::SetMethod(obj, "convert", Convert);
 #define EXPORT_ERRNO(err)                                                     \
     Nan::Set(obj,                                                             \
              Nan::New<String>(#err).ToLocalChecked(),                         \


### PR DESCRIPTION
Let NAN take care of the `ToLocalChecked()` calls and removes direct
reference to `v8::FunctionTemplate`.